### PR TITLE
Limit servo speed for smooth move and preventing potential crash

### DIFF
--- a/Oscillator.cpp
+++ b/Oscillator.cpp
@@ -42,6 +42,7 @@ void Oscillator::attach(int pin, bool rev)
 
     //-- Attach the servo and move it to the home position
       _servo.attach(pin);
+      _pos = 90; 
       _servo.write(90);
 
       //-- Initialization of oscilaltor parameters
@@ -93,7 +94,7 @@ void Oscillator::SetT(unsigned int T)
 
 void Oscillator::SetPosition(int position)
 {
-  _servo.write(position+_trim);
+  write(position);
 };
 
 
@@ -111,9 +112,9 @@ void Oscillator::refresh()
       //-- If the oscillator is not stopped, calculate the servo position
       if (!_stop) {
         //-- Sample the sine function and set the servo pos
-         _pos = round(_amplitude * sin(_phase + _phase0) + _offset);
-	       if (_rev) _pos=-_pos;
-         _servo.write(_pos+90+_trim);
+         int pos = round(_amplitude * sin(_phase + _phase0) + _offset);
+	       if (_rev) pos=-pos;
+         write(pos+90);
       }
 
       //-- Increment the phase
@@ -122,4 +123,14 @@ void Oscillator::refresh()
       _phase = _phase + _inc;
 
   }
+}
+
+void Oscillator::write(int position) 
+{
+  if (_diff_limit > 0 && abs(position - _pos) > _diff_limit) {
+    _pos += position < _pos ? -_diff_limit : _diff_limit;
+  } else {
+    _pos = position;
+  }
+  _servo.write(_pos + _trim);
 }

--- a/Oscillator.h
+++ b/Oscillator.h
@@ -22,7 +22,7 @@
 class Oscillator
 {
   public:
-    Oscillator(int trim=0) {_trim=trim;};
+    Oscillator(int trim=0) {_trim=trim; _diff_limit = 0; };
     void attach(int pin, bool rev =false);
     void detach();
     
@@ -31,15 +31,19 @@ class Oscillator
     void SetPh(double Ph) {_phase0=Ph;};
     void SetT(unsigned int period);
     void SetTrim(int trim){_trim=trim;};
+    void SetLimiter(int diff_limit) { _diff_limit = diff_limit; };
+    void DisableLimiter() { _diff_limit = 0; };
     int getTrim() {return _trim;};
     void SetPosition(int position); 
     void Stop() {_stop=true;};
     void Play() {_stop=false;};
     void Reset() {_phase=0;};
     void refresh();
-    
+    int getPosition() { return _pos;}
+
   private:
     bool next_sample();  
+    void write(int position);
     
   private:
     //-- Servo that is attached to the oscillator
@@ -67,6 +71,12 @@ class Oscillator
 
     //-- Reverse mode
     bool _rev;
+
+    // -- Limit of the angle delta send to servos
+    //    This is for smooth movement and preventing Ardino to crash 
+    //    because of the high current consumed by servo motors.
+    //    set 0 for disabling the limiter
+    int  _diff_limit;  
 };
 
 #endif

--- a/Otto.cpp
+++ b/Otto.cpp
@@ -1071,13 +1071,7 @@ void Otto::playGesture(int gesture){
   }
 } 
 
-void Otto::enableServoLimit() {
-  for (int i = 0; i < 4; i++) {
-    servo[i].SetLimiter(SERVO_LIMIT_DEFAULT);
-  }
-}
-
-void Otto::adjustServoLimit(int diff_limit) {
+void Otto::enableServoLimit(int diff_limit) {
   for (int i = 0; i < 4; i++) {
     servo[i].SetLimiter(diff_limit);
   }

--- a/Otto.cpp
+++ b/Otto.cpp
@@ -25,8 +25,6 @@ void Otto::init(int YL, int YR, int RL, int RR, bool load_calibration, int Buzze
     }
   }
 
-  for (int i = 0; i < 4; i++) servo_position[i] = 90;
-
   //Buzzer pin:
   pinBuzzer = Buzzer;
   pinMode(Buzzer,OUTPUT);
@@ -85,19 +83,18 @@ void Otto::_moveServos(int time, int  servo_target[]) {
   }
 
   if(time>10){
-    for (int i = 0; i < 4; i++) increment[i] = ((servo_target[i]) - servo_position[i]) / (time / 10.0);
+    for (int i = 0; i < 4; i++) increment[i] = ((servo_target[i]) - servo[i].getPosition()) / (time / 10.0);
     final_time =  millis() + time;
 
     for (int iteration = 1; millis() < final_time; iteration++) {
       partial_time = millis() + 10;
-      for (int i = 0; i < 4; i++) servo[i].SetPosition(servo_position[i] + (iteration * increment[i]));
+      for (int i = 0; i < 4; i++) servo[i].SetPosition(servo[i].getPosition() + (iteration * increment[i]));
       while (millis() < partial_time); //pause
     }
   }
   else{
     for (int i = 0; i < 4; i++) servo[i].SetPosition(servo_target[i]);
   }
-  for (int i = 0; i < 4; i++) servo_position[i] = servo_target[i];
 }
 
 void Otto::_moveSingle(int position, int servo_number) {
@@ -1073,3 +1070,21 @@ void Otto::playGesture(int gesture){
 
   }
 } 
+
+void Otto::enableServoLimit() {
+  for (int i = 0; i < 4; i++) {
+    servo[i].SetLimiter(SERVO_LIMIT_DEFAULT);
+  }
+}
+
+void Otto::adjustServoLimit(int diff_limit) {
+  for (int i = 0; i < 4; i++) {
+    servo[i].SetLimiter(diff_limit);
+  }
+}
+
+void Otto::disableServoLimit() {
+  for (int i = 0; i < 4; i++) {
+    servo[i].DisableLimiter();
+  }
+}

--- a/Otto.h
+++ b/Otto.h
@@ -85,8 +85,7 @@ class Otto
     void writeText (const char * s, byte scrollspeed);
 
     // -- Servo limiter
-    void enableServoLimit();
-    void adjustServoLimit(int limit);
+    void enableServoLimit(int diff_limit = SERVO_LIMIT_DEFAULT);
     void disableServoLimit();
 
   private:

--- a/Otto.h
+++ b/Otto.h
@@ -22,6 +22,9 @@
 #define MEDIUM      15
 #define BIG         30
 
+// -- Servo delta limit default
+#define SERVO_LIMIT_DEFAULT 6
+
 class Otto
 {
   public:
@@ -80,13 +83,18 @@ class Otto
     void matrixIntensity(int intensity);
     void setLed(byte X, byte Y, byte value);
     void writeText (const char * s, byte scrollspeed);
+
+    // -- Servo limiter
+    void enableServoLimit();
+    void adjustServoLimit(int limit);
+    void disableServoLimit();
+
   private:
 
     Oscillator servo[4];
     Otto_Matrix ledmatrix;
     int servo_pins[4];
     int servo_trim[4];
-    int servo_position[4];
 
     int pinBuzzer;
 


### PR DESCRIPTION
# About this change

Servo motors sometimes move too aggressively typically when a motion moves to another and it sometimes makes the arduino crash because of the high current drained into the motors.
This change limits the speed of the servo motors by having the previous position and checking the differences.
For backward compatibility, this feature is disabled by default. This feature is enabled by adding the following code into the Otto Blockly / Arduino projects.

```
     Otto.enableServoLimit();
```

Following is the example to apply the feature into a Otto blockly project.

![screenshot1](https://user-images.githubusercontent.com/89312322/135737970-1dd36a32-115f-4373-b9ec-b3f2cb32f95b.png)

Following is the effect (videos):

**No limit**
https://drive.google.com/file/d/1ind8VeGXa1izIdFk42XV6do8Ohr1Dj4j/view?usp=sharing

**Apply the limiter**
https://drive.google.com/file/d/1TL_hsLVUXM647yDn95L8NPz5rY-kRKCl/view?usp=sharing

You also can adjust the limit by putting a parameter when you call enableServoLimit() function. The default is 6 which means, for each command to servo, the servo speed is limited to 6 degrees to the previous angle. This library typically sends commands to servo in 10msec / 30msec intervals and setting 5 or 6 was the reasonable limit at my test.
Following is the example to set the limit to 3.

![screenshot2](https://user-images.githubusercontent.com/89312322/135738152-0aba78ba-a659-4a96-8414-626754cf93ae.png)
 
Following is the motion (video) when the limit is set to 3. You can see the movement become more conservative 
https://drive.google.com/file/d/10tdl7VoxpnufJ3F-akJPz1v52Ke-LKhh/view?usp=sharing

# Note
I propose this as an optional feature of this library this time but I feel this could be the feature turned on by default for make the Otto's move safer and stable side. Advanced developer can disable for their aggressive moves.
