### PR TITLE
Improving RAM footprint decreasing the memory usage by serial command identifiers

### DIFF
--- a/src/SerialCommand.cpp
+++ b/src/SerialCommand.cpp
@@ -124,7 +124,7 @@ void SerialCommand::readSerial()
 				Serial.println("]");
 				#endif
 				// Compare the found command against the list of known commands for a match
-				if (strncmp(token,CommandList[i].command,SERIALCOMMANDBUFFER) == 0) 
+				if (strncmp(token,CommandList[i].command,MAXDELIMETER) == 0) 
 				{
 					#ifdef SERIALCOMMANDDEBUG
 					Serial.print("Matched Command: "); 
@@ -165,7 +165,7 @@ void SerialCommand::addCommand(const char *command, void (*function)())
 		Serial.println(command); 
 		#endif
 		
-		strncpy(CommandList[numCommand].command,command,SERIALCOMMANDBUFFER); 
+		strncpy(CommandList[numCommand].command,command,MAXDELIMETER); 
 		CommandList[numCommand].function = function; 
 		numCommand++; 
 	} else {

--- a/src/SerialCommand.h
+++ b/src/SerialCommand.h
@@ -17,6 +17,8 @@ Oct 2013 - SerialCommand object can be created using a SoftwareSerial object, fo
            a SoftwareSerial port in the project.  sigh.   See Example Sketch for usage. 
 Oct 2013 - Conditional compilation for the SoftwareSerial support, in case you really, really
            hate it and want it removed.  
+Jun 2022 - Using MAXDELIMETER as maximum length of serial command added when calling addCommand
+		   order to reduce the usage of dynamic memory/RAM footprint.
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -62,7 +64,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <string.h>
 
-
 #define SERIALCOMMANDBUFFER 35
 #define MAXSERIALCOMMANDS	16
 #define MAXDELIMETER 2
@@ -93,7 +94,7 @@ class SerialCommand
 		char *token;                        // Returned token from the command buffer as returned by strtok_r
 		char *last;                         // State variable used by strtok_r during processing
 		typedef struct _callback {
-			char command[SERIALCOMMANDBUFFER];
+			char command[MAXDELIMETER];
 			void (*function)();
 		} SerialCommandCallback;            // Data structure to hold Command/Handler function key-value pairs
 		int numCommand;


### PR DESCRIPTION
When using method addCommand, the identifier has only 2 bytes but they are stored in a struct of 35 bytes, this pull request is a proposal to fix it.
The default library setup, has 16 identifiers of 35 bytes, using 560 bytes. After improvement it will use 32 bytes, a reduction of 528 bytes, or 94%.
It is very significant when using arduino nano that has 2048 Bytes of RAM, an improvement of ~25%.