### PR TITLE
fix repeating input

### DIFF
--- a/examples/Otto_CalibrationWalk/Otto_CalibrationWalk.ino
+++ b/examples/Otto_CalibrationWalk/Otto_CalibrationWalk.ino
@@ -22,7 +22,7 @@ int YL;
 int YR;
 int RL;
 int RR;
-double charRead;
+
 void setup(){
       Otto.init(LeftLeg, RightLeg, LeftFoot, RightFoot, true, Buzzer); //Set the servo pins and Buzzer pin
     Serial.begin(9600);
@@ -46,6 +46,7 @@ void setup(){
 }
 
 void loop(){
+    int charRead = 0;
 
     if((Serial.available()) > (0)){
         charRead = Serial.read();


### PR DESCRIPTION
In the calibration example, once a key was pressed, it got stored in a global variable. This lead to basically repeating this key until another key gets pressed.

This PR changes this behavior to expect one keypress per movement step. Without a keypress, the movement stops now.